### PR TITLE
Release Packages

### DIFF
--- a/.changeset/auto-changeset-swarm-wasp.md
+++ b/.changeset/auto-changeset-swarm-wasp.md
@@ -1,8 +1,0 @@
----
-"@ingenyus/swarm-wasp": major
----
-
-- fix: add support for Wasp 0.21.x ([17028d1](https://github.com/Genyus/swarm/commit/17028d1be57d729dfcd7af9a42f421b0776d33d1))
-- feat!: update dependencies ([be334a5](https://github.com/Genyus/swarm/commit/be334a5b0b45becd501b8db804878233eb66d1d4))
-
-<!-- Authors: Genyus<genyus@gmail.com> -->

--- a/.changeset/auto-changeset-swarm.md
+++ b/.changeset/auto-changeset-swarm.md
@@ -1,7 +1,0 @@
----
-"@ingenyus/swarm": major
----
-
-- feat!: update dependencies ([be334a5](https://github.com/Genyus/swarm/commit/be334a5b0b45becd501b8db804878233eb66d1d4))
-
-<!-- Authors: Genyus<genyus@gmail.com> -->

--- a/packages/swarm-wasp/CHANGELOG.md
+++ b/packages/swarm-wasp/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @ingenyus/swarm-wasp
 
+## [2.0.0][2.0.0] - 2026-02-20
+
+### Major Changes
+
+### ⚠️ Breaking Changes
+
+- update dependencies ([be334a5](https://github.com/genyus/swarm/commit/be334a5b0b45becd501b8db804878233eb66d1d4))
+
+### 🐞 Bug Fixes
+
+- add support for Wasp 0.21.x ([17028d1](https://github.com/genyus/swarm/commit/17028d1be57d729dfcd7af9a42f421b0776d33d1))
+
+### 📦 Updated Dependencies
+
+- update @ingenyus/swarm to 2.0.0 ([be334a5](https://github.com/genyus/swarm/commit/be334a5b0b45becd501b8db804878233eb66d1d4))
+
+Contributors: [genyus](https://github.com/genyus)
+
+[2.0.0]: https://github.com/genyus/swarm/releases/tag/%40ingenyus%2Fswarm-wasp%402.0.0
+
 ## [1.2.0][1.2.0] - 2025-12-23
 
 ### Minor Changes

--- a/packages/swarm-wasp/package.json
+++ b/packages/swarm-wasp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ingenyus/swarm-wasp",
   "type": "module",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Wasp-specific plugins for Swarm - Feature generators, commands, MCP tools, and enhanced Wasp configuration for Wasp development",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/swarm/CHANGELOG.md
+++ b/packages/swarm/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @ingenyus/swarm
 
+## [2.0.0][2.0.0] - 2026-02-20
+
+### Major Changes
+
+### ⚠️ Breaking Changes
+
+- update dependencies ([be334a5](https://github.com/genyus/swarm/commit/be334a5b0b45becd501b8db804878233eb66d1d4))
+
+Contributors: [genyus](https://github.com/genyus)
+
+[2.0.0]: https://github.com/genyus/swarm/releases/tag/%40ingenyus%2Fswarm%402.0.0
+
 ## [1.0.4][1.0.4] - 2025-12-23
 
 ### 🔧 Minor Improvements

--- a/packages/swarm/package.json
+++ b/packages/swarm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ingenyus/swarm",
   "type": "module",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Core Swarm logic - including a CLI, MCP server, plugin framework and base types for custom generators",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## swarm

## [2.0.0][2.0.0] - 2026-02-20

### Major Changes

### ⚠️ Breaking Changes

- update dependencies ([be334a5](https://github.com/genyus/swarm/commit/be334a5b0b45becd501b8db804878233eb66d1d4))

Contributors: [genyus](https://github.com/genyus)

[2.0.0]: https://github.com/genyus/swarm/releases/tag/%40ingenyus%2Fswarm%402.0.0

---

## swarm-wasp

## [2.0.0][2.0.0] - 2026-02-20

### Major Changes

### ⚠️ Breaking Changes

- update dependencies ([be334a5](https://github.com/genyus/swarm/commit/be334a5b0b45becd501b8db804878233eb66d1d4))

### 🐞 Bug Fixes

- add support for Wasp 0.21.x ([17028d1](https://github.com/genyus/swarm/commit/17028d1be57d729dfcd7af9a42f421b0776d33d1))

### 📦 Updated Dependencies

- update @ingenyus/swarm to 2.0.0 ([be334a5](https://github.com/genyus/swarm/commit/be334a5b0b45becd501b8db804878233eb66d1d4))

Contributors: [genyus](https://github.com/genyus)

[2.0.0]: https://github.com/genyus/swarm/releases/tag/%40ingenyus%2Fswarm-wasp%402.0.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release bookkeeping only (version/changelog/changeset updates) with no runtime code changes.
> 
> **Overview**
> Cuts a `2.0.0` release for `@ingenyus/swarm` and `@ingenyus/swarm-wasp`, bumping both `package.json` versions to `2.0.0` and adding corresponding `CHANGELOG.md` entries.
> 
> Removes the pending `.changeset/*` release notes files now that the release notes are captured in the changelogs (including the noted breaking dependency updates and the Wasp `0.21.x` support fix in `swarm-wasp`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e393fbf912e5fecfd5e824d5659d174c7cd0ebc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->